### PR TITLE
Support for using pwsh instead of powershell

### DIFF
--- a/example/PSCore.js
+++ b/example/PSCore.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const PowerShell = require("../lib");
+
+// Start the process
+let ps = new PowerShell("echo 'powershell is awesome'",{PSCore:true});
+
+// Handle process errors (e.g. powershell not found)
+ps.on("error", err => {
+    console.error(err);
+});
+
+// Stdout
+ps.on("output", data => {
+    console.log(data);
+});
+
+// Stderr
+ps.on("error-output", data => {
+    console.error(data);
+});
+
+// End
+ps.on("end", code => {
+    // Do Something on end
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,6 @@ const isUndefined = require("is-undefined")
     , isWin = require("is-win")
     ;
 
-const EXE_NAME = `powershell${isWin() ? ".exe" : ""}`;
-
 module.exports = class PowerShell extends EventEmitter {
     /**
      * PowerShell
@@ -20,7 +18,8 @@ module.exports = class PowerShell extends EventEmitter {
      *  - `debug` (Boolean): Turn on/off the debug messages (default: `false`).
      *  - `noprofile` (Boolean): Turn on/off noprofile parameter (default: `true`).
      *  - `executionpolicy` (Enum): Run powershell with specified executionpolicy (default: System default). Valid enum values are `Restricted`, `AllSigned`, `RemoteSigned`, `Unrestricted`, `Bypass`, `Undefined`.
-     *
+     *  - `PSCore` (Boolean) : Turn on/off 'pwsh' the executable for PowerShell Core as opposed to Windowes PowerShell (default: 'false').
+     * 
      * @param {Function} cb The callback function (optional).
      */
     constructor (input, opt, cb){
@@ -29,7 +28,8 @@ module.exports = class PowerShell extends EventEmitter {
         opt = opt || {};
         opt.debug = isUndefined(opt.debug) ? false : opt.debug;
         opt.noprofile = isUndefined(opt.noprofile) ? true : opt.noprofile;
-
+        opt.PSCore = isUndefined(opt.PSCore) ? false : opt.PSCore;
+        const EXE_NAME = `${opt.PSCore?'pwsh':'powershell'}${isWin() ? ".exe" : ""}`;
         let args = [];
 
         if (opt.noprofile) {


### PR DESCRIPTION
In PowerShell Core the PowerShell executable was renamed to pwsh as to preserve all the legacy PowerShell scripts which will always use powershell/powershell.exe

This PR adds support for pwsh via a parameter.  PowerShellCore and WindowsPowerShell need to be run side-by-side for the foreseeable future which is the reason for this change.  Also I think you want to keep your cool powershell for node.js library attractive for Mac and Linux which use PSCore.